### PR TITLE
Remove unused OpenAI imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 # app.py
 
 import streamlit as st
-from writer_agent import read_config, setup_agent, generate_blog_post
+from writer_agent import setup_agent, generate_blog_post
 from reviewer_agent import setup_reviewer_chain, evaluate_blog_post
 #import yaml
 
@@ -131,7 +131,7 @@ def main():
                                 score = int(value.strip().split("/")[0])
                                 scores[key.strip()] = score
                                 total_score += score
-                            except:
+                            except Exception:
                                 continue
 
                     st.markdown(f"**総合点数:** {total_score}/25")

--- a/reviewer_agent.py
+++ b/reviewer_agent.py
@@ -1,21 +1,7 @@
-import yaml
-import openai
 from langchain import LLMChain, PromptTemplate
-from langchain.llms import OpenAI
 from langchain_community.chat_models import ChatOpenAI
 import os
 
-def read_config(config_path: str) -> dict:
-    try:
-        with open(config_path, 'r') as file:
-            config = yaml.safe_load(file)
-        return config
-    except FileNotFoundError:
-        print(f"設定ファイル {config_path} が見つかりません。")
-        return {}
-    except yaml.YAMLError as e:
-        print(f"YAMLファイルの解析エラー: {e}")
-        return {}
 
 def setup_reviewer_chain(openai_api_key: str, prompt_template: str) -> LLMChain:
     os.environ["OPENAI_API_KEY"] = openai_api_key

--- a/writer_agent.py
+++ b/writer_agent.py
@@ -1,24 +1,8 @@
-import yaml
-import openai
 from langchain.agents import initialize_agent, Tool, AgentExecutor
 from langchain.agents import AgentType
-#from langchain.llms import OpenAI
-from langchain_community.llms import OpenAI
 from langchain.utilities import SerpAPIWrapper
 from langchain_openai import ChatOpenAI
 import os
-
-def read_config(config_path: str) -> dict:
-    try:
-        with open(config_path, 'r') as file:
-            config = yaml.safe_load(file)
-        return config
-    except FileNotFoundError:
-        print(f"設定ファイル {config_path} が見つかりません。")
-        return {}
-    except yaml.YAMLError as e:
-        print(f"YAMLファイルの解析エラー: {e}")
-        return {}
 
 def setup_agent(openai_api_key: str, serpapi_api_key: str) -> any:
     os.environ["OPENAI_API_KEY"] = openai_api_key


### PR DESCRIPTION
## Summary
- drop the `read_config` helpers
- remove unused `openai` and `OpenAI` imports
- adjust app to use cleaned writer module
- fix bare `except` for linting

## Testing
- `ruff check .`
- `pytest -q` *(fails: command not found)*